### PR TITLE
New function AIPS2HOPS_ANT(AIPS_ANT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Test
 Testing Commits etc.
+
+New function AIPS2HOPS_ANT(AIPS_ANT)
+* Create a separate function to convert AIPS_ANT to HOPS_ANT i.e. given antenna names in AIPS convention ('AA', 'SM' etc), convert them to HOPS convention ('A', 'S' etc). 


### PR DESCRIPTION
* Create a separate function to convert AIPS_ANT to HOPS_ANT i.e. given antenna names in AIPS convention ('AA', 'SM' etc), convert them to HOPS convention ('A', 'S' etc).